### PR TITLE
chore: Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This is a public repo, require InfoSec review
+* @GlossGenius/infosec


### PR DESCRIPTION
Add InfoSec as default reviewer as repo is public